### PR TITLE
Update neonboost.asl

### DIFF
--- a/neonboost/neonboost.asl
+++ b/neonboost/neonboost.asl
@@ -138,6 +138,7 @@ onStart
 {
   vars.completedSplits.Clear();
   vars.address = null;
+  vars.finalPoints = 0;
 }
 
 isLoading


### PR DESCRIPTION
Resetting vars.finalPoints on start to exclude accidental splitting at entering last level